### PR TITLE
Fix unpiping, splice index and removeListener

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -148,30 +148,30 @@ Pipeline.prototype = {
    * @param {Stream} stream
    * @return {Number} index
    */
-  indexOf: function( stream ) {
-    return this._streams.indexOf( stream )
+  indexOf: function( stream, fromIndex ) {
+    return this._streams.indexOf( stream, fromIndex )
   },
 
   /**
-   * Append given streams to the pipeline
+   * Append given streams to the pipeline, analog to Array#push()
    * @param  {...Stream} streams - streams to append
    * @return {Pipeline}
    */
   append() {
     var streams = Array.prototype.slice.call( arguments )
     this.splice.apply( this, [ this._streams.length, 0 ].concat( streams ) )
-    return this
+    return this.length
   },
 
   /**
-   * Prepend given streams to the pipeline
+   * Prepend given streams to the pipeline, analog to Array#unshift()
    * @param  {...Stream} streams - streams to prepend
    * @return {Pipeline}
    */
   prepend() {
     var streams = Array.prototype.slice.call( arguments )
     this.splice.apply( this, [ 0, 0 ].concat( streams ) )
-    return this
+    return this.length
   },
 
   /**
@@ -200,7 +200,7 @@ Pipeline.prototype = {
   splice( index, remove ) {
 
     // Support negative indices
-    index = index > 0 ? index : this._streams.length - index
+    index = index >= 0 ? index : this._streams.length + index
 
     // Default to removal of everything > index
     remove = remove != null ? remove : this._streams.length - index
@@ -215,13 +215,13 @@ Pipeline.prototype = {
     }
 
     // Unpipe slice end
-    if( this._streams[ lastIndex ] && this._streams[ lastIndex + 1 ] ) {
-      this._streams[ lastIndex ].unpipe( this._streams[ lastIndex + 1 ] )
+    if( this._streams[ lastIndex - 1 ] && this._streams[ lastIndex ] ) {
+      this._streams[ lastIndex - 1 ].unpipe( this._streams[ lastIndex ] )
     }
 
     // Remove the last stream's 'end' handler
     if( this._streams.length !== 0 ) {
-      this.get(-1).removeEventListener( 'end', this._endHandler )
+      this.get(-1).removeListener( 'end', this._endHandler )
     }
 
     // Pipe to-be-inserted streams
@@ -236,7 +236,7 @@ Pipeline.prototype = {
 
     // Unpipe removed streams
     for( i = 0; i < removed.length; i++ ) {
-      removed[i].removeEventListener( 'error', this._errorHandler )
+      removed[i].removeListener( 'error', this._errorHandler )
       if( removed[ i + 1 ] == null ) continue
       removed[i].unpipe( removed[ i + 1 ] )
     }
@@ -244,25 +244,23 @@ Pipeline.prototype = {
     lastIndex = index + streams.length
 
     // Re-pipe slice start
-    if( this._streams[ index - 1 ] ) {
+    if( this._streams[ index - 1 ] && this._streams[ index ] ) {
       this._streams[ index - 1 ].pipe( this._streams[ index ] )
     }
 
     // Re-pipe slice end
-    if( this._streams[ lastIndex ] && this._streams[ lastIndex + 1 ] ) {
-      this._streams[ lastIndex ].pipe( this._streams[ lastIndex + 1 ] )
+    if( this._streams[ lastIndex - 1 ] && this._streams[ lastIndex ] ) {
+      this._streams[ lastIndex - 1 ].pipe( this._streams[ lastIndex ] )
     }
 
-    // Remove the last stream's 'end' handler
+    // Add the last stream's 'end' handler
     if( this._streams.length !== 0 ) {
       this.get(-1).on( 'end', this._endHandler )
     }
 
     // Trigger the underlying read mechanisms of the new streams,
     // see https://nodejs.org/api/stream.html#stream_readable_read_0
-    for( i = 0; i < streams.length; i++ ) {
-      streams[i].read(0)
-    }
+    this.read(0)
 
     return removed
 

--- a/test/append.js
+++ b/test/append.js
@@ -6,6 +6,14 @@ var Stream = require( 'stream' )
 
 describe( 'Pipeline.append()', function() {
 
+  it( 'returns pipeline length', function() {
+    var pipeline = new Pipeline()
+    assert.strictEqual( pipeline.append( new Stream.PassThrough() ), pipeline.length )
+    assert.strictEqual( pipeline.length, 1 )
+    assert.strictEqual( pipeline.append( new Stream.PassThrough() ), pipeline.length )
+    assert.strictEqual( pipeline.length, 2 )
+  })
+
   it( 'can append a stream', function( done ) {
 
     var streams = []
@@ -13,9 +21,9 @@ describe( 'Pipeline.append()', function() {
     var chunks = []
 
     pipeline
-      .once( 'error', done )
-      .once( 'data', (data) => chunks.push( data ) )
-      .once( 'finish', function() {
+      .on( 'error', done )
+      .on( 'data', (data) => chunks.push( data ) )
+      .on( 'finish', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
@@ -39,9 +47,9 @@ describe( 'Pipeline.append()', function() {
     var chunks = []
 
     pipeline
-      .once( 'error', done )
-      .once( 'data', (data) => chunks.push( data ) )
-      .once( 'finish', function() {
+      .on( 'error', done )
+      .on( 'data', (data) => chunks.push( data ) )
+      .on( 'finish', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })

--- a/test/edge-cases.js
+++ b/test/edge-cases.js
@@ -13,9 +13,9 @@ describe( 'Edge cases', function() {
     var pipeline = new Pipeline( streams )
 
     pipeline
-      .once( 'error', done )
-      .once( 'finish', done )
-      .once( 'readable', function() {
+      .on( 'error', done )
+      .on( 'finish', done )
+      .on( 'readable', function() {
         var hash = this.read()
         assert.equal( hash.toString( 'hex' ), '37a309ae59ad3a562a083eb90e32fa6757bdd41f' )
       })

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,158 @@
+var Pipeline = require( '..' )
+var assert = require( 'assert' )
+var Stream = require( 'stream' )
+
+describe( 'Pipeline#onError', function() {
+
+  it( 'will emit an "error" from the beginning of the pipeline', function( done ) {
+
+    var stream1 = new Stream.PassThrough()
+    var stream2 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().toLowerCase() )
+      }
+    })
+
+    var stream3 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().toUpperCase() )
+      }
+    })
+
+    var pipeline = new Pipeline([ stream1, stream2, stream3 ])
+    var hadError = false
+
+    pipeline.on( 'error', function( error ) {
+      assert.ok( hadError === false, 'only one error emitted' )
+      assert.equal( error.stream, stream1, 'stream reference' )
+      hadError = true
+    })
+
+    pipeline.resume().once( 'finish', function() {
+      done()
+    })
+
+    pipeline.write( 'something' )
+    pipeline.end( 'else' )
+
+    setImmediate( function() {
+      stream1.emit( 'error', new Error( 'Catch me' ) )
+    })
+
+  })
+
+  it( 'will emit each "error" event from all streams in the pipeline', function( done ) {
+
+    var stream1 = new Stream.PassThrough()
+    var stream2 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().toLowerCase() )
+      }
+    })
+
+    var stream3 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().toUpperCase() )
+      }
+    })
+
+    var pipeline = new Pipeline([ stream1, stream2, stream3 ])
+    var hadErrors = 0
+
+    pipeline.on( 'error', function( error ) {
+      assert.ok( error instanceof Error )
+      hadErrors++
+      if( hadErrors === 3 ) done()
+    })
+
+    pipeline.resume().once( 'finish', function() {
+      done( new Error( 'Did not error' ) )
+    })
+
+    setImmediate( function() {
+      pipeline.write( 'something' )
+      stream1.emit( 'error', new Error( 'Catch me' ) )
+      setImmediate( function() {
+        stream2.emit( 'error', new Error( 'Catch me' ) )
+        pipeline.end( 'else' )
+        stream3.emit( 'error', new Error( 'Catch me' ) )
+      })
+    })
+
+  })
+
+  it( 'will emit an "error" from the middle of the pipeline', function( done ) {
+
+    var stream1 = new Stream.PassThrough()
+    var stream2 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().toLowerCase() )
+      }
+    })
+
+    var stream3 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().toUpperCase() )
+      }
+    })
+
+    var pipeline = new Pipeline([ stream1, stream2, stream3 ])
+    var hadError = false
+
+    pipeline.on( 'error', function( error ) {
+      assert.ok( hadError === false, 'only one error emitted' )
+      assert.equal( error.stream, stream2, 'stream reference' )
+      hadError = true
+    })
+
+    pipeline.resume().once( 'finish', function() {
+      done()
+    })
+
+    pipeline.write( 'something' )
+    pipeline.end( 'else' )
+
+    setImmediate( function() {
+      stream2.emit( 'error', new Error( 'Catch me' ) )
+    })
+
+  })
+
+  it( 'will emit an "error" from the end of the pipeline', function( done ) {
+
+    var stream1 = new Stream.PassThrough()
+    var stream2 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().toLowerCase() )
+      }
+    })
+
+    var stream3 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().toUpperCase() )
+      }
+    })
+
+    var pipeline = new Pipeline([ stream1, stream2, stream3 ])
+    var hadError = false
+
+    pipeline.on( 'error', function( error ) {
+      assert.ok( hadError === false, 'only one error emitted' )
+      assert.equal( error.stream, stream3, 'stream reference' )
+      hadError = true
+    })
+
+    pipeline.resume().once( 'finish', function() {
+      done()
+    })
+
+    pipeline.write( 'something' )
+    pipeline.end( 'else' )
+
+    setImmediate( function() {
+      stream3.emit( 'error', new Error( 'Catch me' ) )
+    })
+
+  })
+
+})

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -6,6 +6,13 @@ var Stream = require( 'stream' )
 
 describe( 'Pipeline.prepend()', function() {
 
+  it( 'returns pipeline length', function() {
+    var pipeline = new Pipeline()
+    var stream = new Stream.PassThrough()
+    assert.strictEqual( pipeline.prepend( stream ), pipeline.length )
+    assert.strictEqual( pipeline.length, 1 )
+  })
+
   it( 'can prepend a stream', function( done ) {
 
     var streams = []
@@ -13,9 +20,9 @@ describe( 'Pipeline.prepend()', function() {
     var chunks = []
 
     pipeline
-      .once( 'error', done )
-      .once( 'data', (data) => chunks.push( data ) )
-      .once( 'finish', function() {
+      .on( 'error', done )
+      .on( 'data', (data) => chunks.push( data ) )
+      .on( 'finish', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
@@ -39,9 +46,9 @@ describe( 'Pipeline.prepend()', function() {
     var chunks = []
 
     pipeline
-      .once( 'error', done )
-      .once( 'data', (data) => chunks.push( data ) )
-      .once( 'finish', function() {
+      .on( 'error', done )
+      .on( 'data', (data) => chunks.push( data ) )
+      .on( 'finish', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })

--- a/test/splice.js
+++ b/test/splice.js
@@ -1,0 +1,114 @@
+var Pipeline = require( '..' )
+var assert = require( 'assert' )
+var Stream = require( 'stream' )
+
+describe( 'Pipeline.splice()', function() {
+
+  it( 'inserts streams at positive indices', function( done ) {
+
+    var transf1 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().replace( /e/g, '1' ) )
+      }
+    })
+
+    var transf2 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().replace( /1/g, '2' ) )
+      }
+    })
+
+    var transf3 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().replace( /2/gi, '-' ) )
+      }
+    })
+
+    var chunks = []
+    var pipeline = new Pipeline([
+      new Stream.PassThrough(),
+      new Stream.PassThrough(),
+      new Stream.PassThrough(),
+    ])
+
+    pipeline
+      .on( 'error', done )
+      .on( 'data', function( chunk ) { chunks.push( chunk ) })
+      .on( 'finish', function() {
+        assert.equal( chunks.join(''), 'd-adb--f' )
+        done()
+      })
+
+    pipeline.splice( 0, 0, transf1 )
+    assert.strictEqual( pipeline.length, 4 )
+    assert.ok( pipeline.get( 0 ) === transf1, 'incorrect position' )
+
+    pipeline.splice( 2, 0, transf2 )
+    assert.strictEqual( pipeline.length, 5 )
+    assert.ok( pipeline.get( 2 ) === transf2, 'incorrect position' )
+
+    pipeline.splice( pipeline.length, 0, transf3 )
+    assert.strictEqual( pipeline.length, 6 )
+    assert.ok( pipeline.get( 5 ) === transf3, 'incorrect position' )
+
+    pipeline.write( 'dead' )
+    pipeline.write( 'beef' )
+    pipeline.end()
+
+  })
+
+  it( 'inserts streams at negative indices', function( done ) {
+
+    var transf1 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().replace( /e/g, '1' ) )
+      }
+    })
+
+    var transf2 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().replace( /1/g, '2' ) )
+      }
+    })
+
+    var transf3 = new Stream.Transform({
+      transform: function( chunk, _, next ) {
+        next( null, chunk.toString().replace( /2/gi, '-' ) )
+      }
+    })
+
+    var chunks = []
+    var pipeline = new Pipeline([
+      new Stream.PassThrough(),
+      new Stream.PassThrough(),
+      new Stream.PassThrough(),
+    ])
+
+    pipeline
+      .on( 'error', done )
+      .on( 'data', function( chunk ) { chunks.push( chunk ) })
+      .on( 'finish', function() {
+        assert.equal( chunks.join(''), 'd-adb--f' )
+        done()
+      })
+
+    pipeline.splice( -pipeline.length, 0, transf1 )
+    assert.strictEqual( pipeline.length, 4 )
+    assert.ok( pipeline.get( 0 ) === transf1, 'incorrect position' )
+
+    pipeline.splice( -2, 0, transf2 )
+    assert.strictEqual( pipeline.length, 5 )
+    assert.ok( pipeline.get( 2 ) === transf2, 'incorrect position' )
+
+    // Note that -1 inserts *before* the last stream in the pipeline
+    pipeline.splice( -1, 0, transf3 )
+    assert.strictEqual( pipeline.length, 6 )
+    assert.ok( pipeline.get( 4 ) === transf3, 'incorrect position' )
+
+    pipeline.write( 'dead' )
+    pipeline.write( 'beef' )
+    pipeline.end()
+
+  })
+
+})

--- a/test/streams.js
+++ b/test/streams.js
@@ -10,13 +10,13 @@ describe( 'Pipeline', function() {
     var chunks = []
 
     pipeline
-      .once( 'error', done )
-      .once( 'readable', function() {
+      .on( 'error', done )
+      .on( 'readable', function() {
         while( data = this.read() ) {
           chunks.push( data )
         }
       })
-      .once( 'finish', function() {
+      .on( 'finish', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
@@ -43,19 +43,19 @@ describe( 'Pipeline', function() {
     var chunks = []
 
     pipeline
-      .once( 'error', done )
-      .once( 'readable', function() {
+      .on( 'error', done )
+      .on( 'readable', function() {
         while( data = this.read() ) {
           chunks.push( data )
         }
       })
-      .once( 'finish', function() {
+      .on( 'finish', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
 
-    pipeline.write( 'dead' )
-    pipeline.write( 'beef' )
+    pipeline.write( 'Dead' )
+    pipeline.write( 'Beef' )
     pipeline.end()
 
   })
@@ -77,19 +77,19 @@ describe( 'Pipeline', function() {
     var chunks = []
 
     pipeline
-      .once( 'error', done )
-      .once( 'readable', function() {
+      .on( 'error', done )
+      .on( 'readable', function() {
         while( data = this.read() ) {
           chunks.push( data )
         }
       })
-      .once( 'finish', function() {
+      .on( 'finish', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
 
-    pipeline.write( 'dead' )
-    pipeline.write( 'beef' )
+    pipeline.write( 'Dead' )
+    pipeline.write( 'Beef' )
     pipeline.end()
 
   })


### PR DESCRIPTION
**Changes:**
- Fix off-by-one index when unpiping the spliced slice end
- Fix wrong comparison operator for splice index default
- Fix event listener removal method name
- Fix return values of `.append()` and `.prepend()`
- Add missing `fromIndex` argument to `.indexOf()`
- Add splice & error propagation tests
- Change `.once()` listeners to `.on()` to catch multiple callback errors
