### PR TITLE
fix(pipeline): Fix readable state

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -1,11 +1,12 @@
+'use strict'
+
 var Stream = require( 'stream' )
-var inherit = require( 'bloodline' )
 var debug = require( 'debug' )( 'pipage' )
 
 /**
- * Stream Pipeline
- * @constructor
+ * @class Pipeline
  * @extends {Stream.Duplex}
+ * @summary Create a stream pipeline
  * @param {Stream[]} [streams]
  * @param {Object} [options]
  * @param {Number} [options.highWaterMark=16384]
@@ -16,62 +17,102 @@ var debug = require( 'debug' )( 'pipage' )
  * @see https://nodejs.org/api/stream.html#stream_new_stream_duplex_options
  * @returns {Pipeline}
  */
-function Pipeline( streams, options ) {
+class Pipeline extends Stream.Duplex {
 
-  if( !(this instanceof Pipeline) )
-    return new Pipeline( streams, options )
+  constructor( streams, options ) {
 
-  var self = this
-
-  if( streams && !Array.isArray( streams ) ) {
-    options = streams
-    streams = null
-  }
-
-  Stream.Duplex.call( this, options )
-
-  this._streams = []
-  this._isReading = false
-
-  this._errorHandler = function( error ) {
-    error.stream = this
-    self.emit( 'error', error )
-  }
-
-  this._endHandler = function() {
-    if( self.get(-1) === this ) {
-      Stream.Duplex.prototype.end.call(self)
+    if( !Array.isArray(streams) ) {
+      options = streams
+      streams = null
     }
-  }
 
-  this._readHandler = function() {
-    var chunk = null
-    while( chunk = this.read() ) {
-      self.push( chunk )
+    super(options)
+
+    var self = this
+
+    this._streams = []
+
+    this._endHandler = () => {
+      this.push( null )
     }
-    self._isReading = false
-    self._read()
+
+    this._readHandler = () => {
+      this.emit( '_read' )
+    }
+
+    this._errorHandler = function( error ) {
+      error.stream = this
+      self.emit( 'error', error )
+    }
+
+    this.on( 'finish', () => {
+      if( this._streams.length ) {
+        this._streams[0].end()
+      } else {
+        this.push( null )
+      }
+    })
+
+    this.on( 'end', () => {
+      debug( 'ended' )
+    })
+
+    if(Array.isArray(streams)) {
+      this.splice.apply( this, [ 0, 0 ].concat( streams ) )
+    }
+
   }
 
-  // Splice the passed streams into the pipeline
-  if( Array.isArray( streams ) && streams.length ) {
-    this.splice.apply( this, [ 0, 0 ].concat( streams ) )
-  }
-
-}
-
-/**
- * Pipeline prototype
- * @type {Object}
- * @ignore
- */
-Pipeline.prototype = {
-
-  constructor: Pipeline,
-
+  /** @type {Number} length */
   get length() {
     return this._streams.length
-  },
+  }
+
+  /**
+   * Unpipe & unbind events before
+   * mutating the internal pipeline
+   * @private
+   * @returns {undefined}
+   */
+  _beforeMutate() {
+
+    if( this._streams.length ) {
+      this._streams[ this._streams.length - 1 ]
+        .removeListener( 'readable', this._readHandler )
+        .removeListener( 'end', this._endHandler )
+    }
+
+    this._streams.forEach(( stream, i ) => {
+      const next = this._streams[i+1]
+      if(next) {
+        stream.unpipe(next)
+      }
+    })
+
+  }
+
+  /**
+   * Re-pipe & bind events after
+   * mutating the internal pipeline
+   * @private
+   * @returns {undefined}
+   */
+  _afterMutate() {
+
+    if( this._streams.length ) {
+      this._streams[ this._streams.length - 1 ]
+        .on( 'readable', this._readHandler )
+        .on( 'end', this._endHandler )
+    }
+
+    this._streams.forEach(( stream, i ) => {
+      const next = this._streams[i+1]
+      if(next) {
+        stream.pipe(next)
+      }
+    })
+
+  }
 
   /**
    * Read data from the end of the stream
@@ -80,14 +121,27 @@ Pipeline.prototype = {
    */
   _read() {
 
-    if( this._isReading || this._streams.length === 0 ) {
-      return
+    const stream = this._streams[ this._streams.length - 1 ]
+
+    if( !stream ) return;
+
+    let chunk = null
+    let reads = 0
+
+    while( (chunk = stream.read()) != null ) {
+      reads++
+      if( !this.push( chunk ) ) {
+        break
+      }
     }
 
-    this._isReading = true
-    this.get(-1).once( 'readable', this._readHandler )
+    if( reads === 0 ) {
+      this.once( '_read', () => {
+        this._read()
+      })
+    }
 
-  },
+  }
 
   /**
    * Send data into the underlying streams
@@ -97,42 +151,37 @@ Pipeline.prototype = {
    * @param {Function} next(error,chunk)
    * @returns {Boolean}
    */
-  _write( chunk, encoding, next ) {
+  _write(chunk, encoding, next) {
 
-    if( this._streams.length === 0 ) {
-      process.nextTick( next )
-      return this.push( chunk, encoding )
+    if( !this._streams.length ) {
+      this.push( chunk, encoding )
+      return next()
     }
 
-    return this._streams[0]._write( chunk, encoding, next )
+    return this._streams[0].write( chunk, encoding, next )
 
-  },
+  }
 
   /**
    * End the pipeline
-   * NOTE: We need to override this here,
-   * because `crypto.Hash` streams will only emit
-   * a 'readable' event once ended
    * @param {*} chunk
    * @param {String} encoding
    * @param {Function} callback – called on 'finish'
    * @returns {undefined}
    */
-  end( chunk, encoding, callback ) {
+  end(chunk, encoding, callback) {
 
-    debug( 'end', !!chunk, !!callback )
+    debug('end')
 
-    if( typeof callback === 'function' ) {
+    if( callback ) {
       this.once( 'finish', callback )
     }
 
-    if( this._streams.length !== 0 ) {
-      this.get(0).end( chunk, encoding )
-    } else {
-      Stream.Duplex.prototype.end.call(this, chunk, encoding)
-    }
+    Stream.Duplex.prototype.end.call( this, chunk, encoding, () => {
+      debug( 'finished' )
+    })
 
-  },
+  }
 
   /**
    * Bind to a stream's events, and re-emit them on the pipeline
@@ -170,7 +219,7 @@ Pipeline.prototype = {
 
     return this
 
-  },
+  }
 
   /**
    * Unbind the pipeline from a stream's event(s)
@@ -195,7 +244,7 @@ Pipeline.prototype = {
 
     return this
 
-  },
+  }
 
   /**
    * Unbind the pipeline from all of a stream's bound events
@@ -212,7 +261,7 @@ Pipeline.prototype = {
 
     return this
 
-  },
+  }
 
   /**
    * Get a stream in the pipeline by index
@@ -223,7 +272,7 @@ Pipeline.prototype = {
   get( index ) {
     index = index >= 0 ? index : this._streams.length + index
     return this._streams[ index ]
-  },
+  }
 
   /**
    * Get the index of a given stream in the pipeline
@@ -231,9 +280,9 @@ Pipeline.prototype = {
    * @param {Number} [fromIndex]
    * @returns {Number} index
    */
-  indexOf: function( stream, fromIndex ) {
+  indexOf( stream, fromIndex ) {
     return this._streams.indexOf( stream, fromIndex )
-  },
+  }
 
   /**
    * Get the last index of a given stream in the pipeline
@@ -241,9 +290,9 @@ Pipeline.prototype = {
    * @param {Number} [fromIndex]
    * @returns {Number} index
    */
-  lastIndexOf: function( stream, fromIndex ) {
+  lastIndexOf( stream, fromIndex ) {
     return this._streams.lastIndexOf( stream, fromIndex )
-  },
+  }
 
   /**
    * Append given streams to the pipeline, analog to Array#push()
@@ -254,7 +303,7 @@ Pipeline.prototype = {
     var streams = Array.prototype.slice.call( arguments )
     this.splice.apply( this, [ this._streams.length, 0 ].concat( streams ) )
     return this.length
-  },
+  }
 
   /**
    * Prepend given streams to the pipeline, analog to Array#unshift()
@@ -265,7 +314,7 @@ Pipeline.prototype = {
     var streams = Array.prototype.slice.call( arguments )
     this.splice.apply( this, [ 0, 0 ].concat( streams ) )
     return this.length
-  },
+  }
 
   /**
    * Shift a stream off of the beginning of the pipeline
@@ -273,7 +322,7 @@ Pipeline.prototype = {
    */
   shift() {
     return this.splice( 0, 1 )[0]
-  },
+  }
 
   /**
    * Pop a stream off of the end of the pipeline
@@ -281,7 +330,7 @@ Pipeline.prototype = {
    */
   pop() {
     return this.splice( this._streams.length - 1, 1 )[0]
-  },
+  }
 
   /**
    * Insert given streams into the pipeline at a given index
@@ -289,7 +338,7 @@ Pipeline.prototype = {
    * @param {...Stream} streams
    * @returns {Number} length
    */
-  insert: function( index ) {
+  insert( index ) {
 
     if( typeof index !== 'number' ) {
       throw new Error( 'Insertion index must be a number' )
@@ -302,17 +351,17 @@ Pipeline.prototype = {
 
     return this.length
 
-  },
+  }
 
   /**
    * Remove a given stream from the pipeline
    * @param {Stream} stream
    * @returns {Stream|null} removed stream
    */
-  remove: function( stream ) {
+  remove( stream ) {
     var index = this.indexOf( stream )
     return ~index ? this.splice( index, 1 )[0] : null
-  },
+  }
 
   /**
    * Splice streams into or out of the pipeline
@@ -335,77 +384,27 @@ Pipeline.prototype = {
 
     debug( 'splice @%s/%s -%s +%s', index, this._streams.length, remove, streams.length )
 
-    // Unpipe slice start
-    if( this._streams[ index - 1 ] ) {
-      debug( 'unpipe:slice-start', index - 1, '<>', index )
-      this._streams[ index - 1 ].unpipe( this._streams[ index ] )
-    }
+    this._beforeMutate()
 
-    // Unpipe slice end
-    if( this._streams[ lastIndex - 1 ] && this._streams[ lastIndex ] ) {
-      debug( 'unpipe:slice-end', lastIndex - 1, '<>', lastIndex )
-      this._streams[ lastIndex - 1 ].unpipe( this._streams[ lastIndex ] )
-    }
-
-    // Remove the last stream's 'end' handler
-    if( this._streams.length !== 0 ) {
-      debug( 'end-handler:off', this._streams.length - 1 )
-      this._streams[ this._streams.length - 1 ].removeListener( 'end', this._endHandler )
-    }
-
-    // Pipe to-be-inserted streams
-    for( i = 0; i < streams.length; i++ ) {
-      if( streams[ i + 1 ] != null ) {
-        debug( 'pipe', i, '->', i + 1 )
-        streams[i].pipe( streams[ i + 1 ] )
-      }
-      streams[i].on( 'error', this._errorHandler )
-    }
+    streams.forEach(( stream ) => {
+      stream.on( 'error', this._errorHandler )
+    })
 
     // Splice streams in/out
     var removed = this._streams.splice.apply( this._streams, [ index, remove ].concat( streams ) )
 
-    // Unpipe removed streams
-    for( i = 0; i < removed.length; i++ ) {
-      if( removed[ i + 1 ] != null ) {
-        debug( 'unpipe', i, '<>', i + 1 )
-        removed[i].unpipe( removed[ i + 1 ] )
-      }
-      removed[i].removeListener( 'error', this._errorHandler )
-      this.unbindAll( removed[i] )
-    }
+    removed.forEach(( stream ) => {
+      stream.removeListener( 'error', this._errorHandler )
+      this.unbindAll(stream)
+    })
 
-    lastIndex = index + streams.length
-
-    // Re-pipe slice start
-    if( this._streams[ index - 1 ] && this._streams[ index ] ) {
-      debug( 'pipe:slice-start', index - 1, '->', index )
-      this._streams[ index - 1 ].pipe( this._streams[ index ] )
-    }
-
-    // Re-pipe slice end
-    if( index !== lastIndex && this._streams[ lastIndex - 1 ] && this._streams[ lastIndex ] ) {
-      debug( 'pipe:slice-end', lastIndex - 1, '->', lastIndex )
-      this._streams[ lastIndex - 1 ].pipe( this._streams[ lastIndex ] )
-    }
-
-    // Add the last stream's 'end' handler
-    if( this._streams.length !== 0 ) {
-      debug( 'end-handler:on', this._streams.length - 1 )
-      this._streams[ this._streams.length - 1 ].on( 'end', this._endHandler )
-    }
-
-    // Trigger the underlying read mechanisms of the new streams,
-    // see https://nodejs.org/api/stream.html#stream_readable_read_0
-    this.read(0)
+    this._afterMutate()
 
     return removed
 
-  },
+  }
 
 }
-
-inherit( Pipeline, Stream.Duplex )
 
 // Exports
 module.exports = Pipeline

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   ],
   "main": "lib/pipeline.js",
   "dependencies": {
-    "bloodline": "^1.0.0",
     "debug": "~2.6.1"
   },
   "devDependencies": {

--- a/test/append.js
+++ b/test/append.js
@@ -21,7 +21,7 @@ describe( 'Pipeline.append()', function() {
     pipeline
       .on( 'error', done )
       .on( 'data', (data) => chunks.push( data ) )
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
@@ -45,7 +45,7 @@ describe( 'Pipeline.append()', function() {
     pipeline
       .on( 'error', done )
       .on( 'data', (data) => chunks.push( data ) )
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })

--- a/test/bind.js
+++ b/test/bind.js
@@ -20,7 +20,7 @@ describe( 'Pipeline.bind()', function() {
         assert.equal( two, 2 )
         assert.equal( three, 3 )
       })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         assert.ok( hadEvent, 'missing custom event' )
         done()
@@ -29,13 +29,13 @@ describe( 'Pipeline.bind()', function() {
     pipeline.bind( emitter, 'custom:event' )
     pipeline.write( 'DEAD' )
 
-    setTimeout( function() {
+    process.nextTick( function() {
       emitter.emit( 'custom:event', 1, 2, 3 )
-      setImmediate( function() {
+      process.nextTick( function() {
         pipeline.write( 'BEEF' )
         pipeline.end()
       })
-    }, 16 )
+    })
 
   })
 

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -4,11 +4,6 @@ var Stream = require( 'stream' )
 
 describe( 'Constructor', function() {
 
-  it( 'can be called without "new" keyword', function() {
-    var pipeline = Pipeline()
-    assert.ok( pipeline instanceof Pipeline, 'instanceof Pipeline' )
-  })
-
   it( 'can be called without arguments', function() {
     var pipeline = new Pipeline()
     assert.ok( pipeline instanceof Pipeline, 'instanceof Pipeline' )

--- a/test/edge-cases.js
+++ b/test/edge-cases.js
@@ -14,10 +14,12 @@ describe( 'Edge cases', function() {
 
     pipeline
       .on( 'error', done )
-      .on( 'finish', done )
+      .on( 'end', done )
       .on( 'readable', function() {
         var hash = this.read()
-        assert.equal( hash.toString( 'hex' ), '37a309ae59ad3a562a083eb90e32fa6757bdd41f' )
+        if( hash != null ) {
+          assert.equal( hash.toString( 'hex' ), '37a309ae59ad3a562a083eb90e32fa6757bdd41f' )
+        }
       })
 
     pipeline.end( 'Let it work!' )

--- a/test/errors.js
+++ b/test/errors.js
@@ -9,13 +9,15 @@ describe( 'Pipeline#onError', function() {
     var stream1 = new Stream.PassThrough()
     var stream2 = new Stream.Transform({
       transform: function( chunk, _, next ) {
-        next( null, chunk.toString().toLowerCase() )
+        this.push( chunk.toString().toLowerCase() )
+        next()
       }
     })
 
     var stream3 = new Stream.Transform({
       transform: function( chunk, _, next ) {
-        next( null, chunk.toString().toUpperCase() )
+        this.push( chunk.toString().toUpperCase() )
+        next()
       }
     })
 
@@ -28,15 +30,15 @@ describe( 'Pipeline#onError', function() {
       hadError = true
     })
 
-    pipeline.resume().once( 'finish', function() {
+    pipeline.resume().once( 'end', function() {
       done()
     })
 
     pipeline.write( 'something' )
-    pipeline.end( 'else' )
 
-    setImmediate( function() {
+    process.nextTick( function() {
       stream1.emit( 'error', new Error( 'Catch me' ) )
+      pipeline.end( 'else' )
     })
 
   })
@@ -65,14 +67,14 @@ describe( 'Pipeline#onError', function() {
       if( hadErrors === 3 ) done()
     })
 
-    pipeline.resume().once( 'finish', function() {
+    pipeline.resume().on( 'end', function() {
       done( new Error( 'Did not error' ) )
     })
 
-    setImmediate( function() {
+    process.nextTick( function() {
       pipeline.write( 'something' )
       stream1.emit( 'error', new Error( 'Catch me' ) )
-      setImmediate( function() {
+      process.nextTick( function() {
         stream2.emit( 'error', new Error( 'Catch me' ) )
         pipeline.end( 'else' )
         stream3.emit( 'error', new Error( 'Catch me' ) )
@@ -105,7 +107,7 @@ describe( 'Pipeline#onError', function() {
       hadError = true
     })
 
-    pipeline.resume().once( 'finish', function() {
+    pipeline.resume().once( 'end', function() {
       done()
     })
 
@@ -142,7 +144,7 @@ describe( 'Pipeline#onError', function() {
       hadError = true
     })
 
-    pipeline.resume().once( 'finish', function() {
+    pipeline.resume().once( 'end', function() {
       done()
     })
 

--- a/test/insert.js
+++ b/test/insert.js
@@ -18,9 +18,9 @@ describe( 'Pipeline.insert()', function() {
     assert.equal( pipeline.length, 2 )
 
     pipeline
-      .once( 'error', done )
-      .once( 'data', (data) => chunks.push( data ) )
-      .once( 'finish', function() {
+      .on( 'error', done )
+      .on( 'data', (data) => chunks.push( data ) )
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'deadbeef' )
         done()
       })
@@ -32,7 +32,8 @@ describe( 'Pipeline.insert()', function() {
 
     insert = new Stream.Transform({
       transform: function( chunk, _, next ) {
-        next( null, chunk.toString().toLowerCase() )
+        this.push( chunk.toString().toLowerCase() )
+        next()
       }
     })
 

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -20,7 +20,7 @@ describe( 'Pipeline.prepend()', function() {
     pipeline
       .on( 'error', done )
       .on( 'data', (data) => chunks.push( data ) )
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
@@ -44,7 +44,7 @@ describe( 'Pipeline.prepend()', function() {
     pipeline
       .on( 'error', done )
       .on( 'data', (data) => chunks.push( data ) )
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })

--- a/test/remove.js
+++ b/test/remove.js
@@ -26,7 +26,7 @@ describe( 'Pipeline.remove()', function() {
     pipeline
       .on( 'error', done )
       .on( 'data', ( data ) => chunks.push( data ) )
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })

--- a/test/splice.js
+++ b/test/splice.js
@@ -34,7 +34,7 @@ describe( 'Pipeline.splice()', function() {
     pipeline
       .on( 'error', done )
       .on( 'data', function( chunk ) { chunks.push( chunk ) })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'd-adb--f' )
         done()
       })
@@ -92,7 +92,7 @@ describe( 'Pipeline.splice()', function() {
     pipeline
       .on( 'error', done )
       .on( 'data', function( chunk ) { chunks.push( chunk ) })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'd-adb--f' )
         done()
       })

--- a/test/streams.js
+++ b/test/streams.js
@@ -12,11 +12,12 @@ describe( 'Pipeline', function() {
     pipeline
       .on( 'error', done )
       .on( 'readable', function() {
+        var data = null
         while( data = this.read() ) {
           chunks.push( data )
         }
       })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
@@ -34,9 +35,10 @@ describe( 'Pipeline', function() {
     var streams = [
       new Stream.Transform({
         transform: function( chunk, _, next ) {
-          next( null, chunk.toString().toUpperCase() )
+          this.push( chunk.toString().toUpperCase() )
+          next()
         }
-      }),
+      })
     ]
 
     var pipeline = new Pipeline( streams )
@@ -45,11 +47,12 @@ describe( 'Pipeline', function() {
     pipeline
       .on( 'error', done )
       .on( 'readable', function() {
+        var data = null
         while( data = this.read() ) {
           chunks.push( data )
         }
       })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })
@@ -79,11 +82,12 @@ describe( 'Pipeline', function() {
     pipeline
       .on( 'error', done )
       .on( 'readable', function() {
+        var data = null
         while( data = this.read() ) {
           chunks.push( data )
         }
       })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         done()
       })

--- a/test/unbind.js
+++ b/test/unbind.js
@@ -14,7 +14,7 @@ describe( 'Pipeline.unbind()', function() {
       .on( 'error', done )
       .on( 'data', (data) => chunks.push( data ) )
       .on( 'custom:event', () => { throw new Error( 'Emitted unbound event' ) })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         assert.equal( emitter.listenerCount( 'custom:event' ), 0 )
         done()
@@ -50,7 +50,7 @@ describe( 'Pipeline.unbindAll()', function() {
       .on( 'custom:event1', () => { throw new Error( 'Emitted unbound event' ) })
       .on( 'custom:event2', () => { throw new Error( 'Emitted unbound event' ) })
       .on( 'custom:event3', () => { throw new Error( 'Emitted unbound event' ) })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         assert.equal( emitter._pipageListeners, null )
         assert.equal( emitter.listenerCount( 'custom:event1' ), 0 )
@@ -65,17 +65,17 @@ describe( 'Pipeline.unbindAll()', function() {
 
     pipeline.write( 'DEAD' )
 
-    setTimeout( function() {
+    process.nextTick( function() {
       pipeline.unbindAll( emitter )
       emitter.emit( 'custom:event1' )
-      setImmediate( function() {
+      process.nextTick( function() {
         emitter.emit( 'custom:event2' )
         pipeline.write( 'BEEF', function() {
           emitter.emit( 'custom:event3' )
         })
         pipeline.end()
       })
-    }, 16 )
+    })
 
   })
 
@@ -89,7 +89,7 @@ describe( 'Pipeline.unbindAll()', function() {
       .on( 'error', done )
       .on( 'data', (data) => chunks.push( data ) )
       .on( 'custom:event', () => { throw new Error( 'Emitted unbound event' ) })
-      .on( 'finish', function() {
+      .on( 'end', function() {
         assert.equal( chunks.join(''), 'DEADBEEF' )
         assert.equal( emitter._pipageListeners, null )
         assert.equal( emitter.listenerCount( 'custom:event' ), 0 )


### PR DESCRIPTION
**Changes:**
- **lib:** Make the Pipeline a `class`, removing the need for the `bloodline` dependency
- **lib:** Reduce unnecessary complexity in `.splice()` through addition of `._beforeMutate()` and `._afterMutate()`
- **lib:** Fix not reading all available chunks in `._read()`, causing a stall when multiple chunks were available while waiting for the "readable" event
- **lib:** Fix `.end()` not always "ending" the pipeline itself
- **lib:** Fix not waiting for the writable state of the pipeline to finish before ending the readable state
- **lib:** Properly end the readable state by pushing `null` only when the writable has finished and all internal streams have ended (their write & read queues empty and flushed)
- **lib:** Fix not triggering internal write logic by using the proper `stream.write()` instead of `stream._write()` in `pipeline._write()`
- **test:** Only end tests on `end` instead of `finish`, waiting for the last readable in the pipeline to end (become empty)

Change-Type: patch